### PR TITLE
First pass at interpolation highlighting.

### DIFF
--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -24,6 +24,11 @@
 ;; single letter matching groups (Chapter 1)
 (defconst scala-syntax:hexDigit-group "0-9A-Fa-f")
 (defconst scala-syntax:UnicodeEscape-re (concat "\\\\u[" scala-syntax:hexDigit-group "]\\{4\\}"))
+(defconst scala-syntax:LiteralDollar-re "\\$\\$")
+(defconst scala-syntax:BareInterpolation1-re "\\$[_a-zA-Z0-9]+%[0-9.]*[a-zA-Z]+")
+(defconst scala-syntax:BareInterpolation2-re "\\$[_a-zA-Z0-9]+")
+(defconst scala-syntax:BracesInterpolation1-re "\\${.+}%[0-9.]*[a-zA-Z]+")
+(defconst scala-syntax:BracesInterpolation2-re "\\${.+}")
 
 (defconst scala-syntax:upper-group "[:upper:]\\$") ;; missing _ to make ids work
 (defconst scala-syntax:upperAndUnderscore-group (concat "_" scala-syntax:upper-group ))
@@ -85,8 +90,13 @@
           "\\|" scala-syntax:UnicodeEscape-re "\\)\\('\\)"))
 
 (defconst scala-syntax:string-escape-re
-  (concat scala-syntax:escapeSequence-re 
-          "\\|" scala-syntax:UnicodeEscape-re))
+  (concat scala-syntax:escapeSequence-re
+          "\\|" scala-syntax:UnicodeEscape-re
+          "\\|" scala-syntax:LiteralDollar-re
+          "\\|" scala-syntax:BareInterpolation1-re
+          "\\|" scala-syntax:BareInterpolation2-re
+          "\\|" scala-syntax:BracesInterpolation1-re
+          "\\|" scala-syntax:BracesInterpolation2-re))
 
 ;; String Literals (Chapter 1.3.5)
 (defconst scala-syntax:stringElement-re


### PR DESCRIPTION
This isn't totally correct, since right now the interpolation rules are
affecting all strings. We'd really like to limit interpolation to strings which
start with some kind of prefix, for instance s or xyz:

```
"that costs $13.99." // no
s"there are $n cats" // yes
s"""do you have any $food?""" // yes
xyz"what does $this mean?" // yes
```

Currently the interpolation affects all strings which is not correct.

There's another wrinkle, which is supporting the ${} syntax. A totally correct
highlighter would need to match braces across lines, since the following is
legal:

```
my $crazy = s"""this is
  all a ${
  val x = init()
  val y = 0
  while (x < 999) {
    if (foo(x)) {
      x += 1
    } else {
      x += 2
    }
    y += blah(x)
  }
} string
constant ${ ns.map { case (a, b) => a + b }.sum } constant
"""
```

As you can see supporting that looks really painful. For now, we're doing
something a lot simpler which will hopefully be right in common cases.
