### PR TITLE
Add customization variable for indent-on-first-asterisk multi-line comment behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ The start of a multi-line comment is indented to the same level with
 code.
 
 If a multi-line comment begins with `/**` it is considered to be a
-scaladoc comment. Scaladoc comments are indented acording to the
-scaladoc style guide.
+scaladoc comment. By default, Scaladoc comments are indented according
+to the scaladoc style guide.
 
 ```
 /** This is a scaladoc comment.
@@ -215,11 +215,16 @@ Other multi-line comments are indented under the first asterisk.
  */
 ```
 
+This default behavior is overridable via the
+*scala-indent:all-multiline-comments-under-first-asterisk* variable.
+When non-nil, all multi-line comments (including those considered
+to be scaladoc comments) will be indented under the first asterisk.
+
 Typing an asterisk in multi-line comment region, at the start of a
 line, will trigger indent. Furthermore, if the configurable variable
-*scala-indent:add-space-for-scaladoc-asterisk* is t (default) and the
-asterisk was the last character on the line, a space will be inserted
-after it.
+*scala-indent:add-space-for-multiline-comment-asterisk* is t (default)
+and the asterisk was the last character on the line, a space will be
+inserted after it.
 
 ## Filling (i.e. word wrap)
 

--- a/scala-mode-map.el
+++ b/scala-mode-map.el
@@ -21,7 +21,7 @@
   (add-hook 'post-self-insert-hook
             'scala-indent:indent-on-special-words)
   (add-hook 'post-self-insert-hook
-            'scala-indent:indent-on-scaladoc-asterisk))
+            'scala-indent:indent-on-multiline-comment))
 
 (when (not scala-mode-map)
   (let ((keymap (make-sparse-keymap)))
@@ -31,4 +31,3 @@
 ;;      ([(control c)(control r)]   'scala-indent:rotate-run-on-strategy)
       ))
      (setq scala-mode-map keymap)))
-  


### PR DESCRIPTION
Lots of open source Scala code doesn't adhere to ScalaDoc's indentation on the second asterisk in multi-line comment blocks. For example, Twitter shies away from the standard ScalaDoc style: http://twitter.github.com/effectivescala/#Formatting-Comments

This patch adds a new customization variable, `scala-indent:all-multiline-comments-under-first-asterisk`, that forces all multi-line comments to indent to the first asterisk. It's set to nil, so `scala-mode2`'s default behavior stays the same. 

I also took the liberty to rename `scala-indent:add-space-for-scaladoc-asterisk` to `scala-indent:add-space-for-multiline-comment-asterisk` in order to not confuse ScalaDoc comments with the more general term of "multi-line comment". The README has been updated to reflect all changes.
