### PR TITLE
Multi-line comment indentation and asterisk-insertion on mid-line return

### DIFF
--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -880,9 +880,21 @@ the line."
 (defun scala-indent:insert-asterisk-on-multiline-comment ()
   "Insert an asterisk at the end of the current line when at the beginning
 of a line inside a multi-line comment "
-  (let ((state (syntax-ppss)))
+  (let ((state (syntax-ppss))
+        (comment-start-pos (nth 8 (syntax-ppss))))
     (when (and (integerp (nth 4 state))
-               (string-match-p "^\\s-*$" (thing-at-point 'line)))
+               ; Ensure that we're inside a scaladoc comment
+               (string-match-p "^/\\*\\*[^\\*]"
+                               (buffer-substring-no-properties
+                                comment-start-pos
+                                (+ comment-start-pos 4)))
+               ; Ensure that the previous line had a leading asterisk or was the comment start.
+               (let ((prev-line (buffer-substring-no-properties
+                                 (line-beginning-position 0)
+                                 (line-end-position 0))))
+                 (or
+                  (string-match-p "^\\s-*\\*" prev-line)
+                  (string-match-p "\\s-*/\\*\\*" prev-line))))
       (skip-syntax-forward " ")
       (insert "*")
       (scala-indent:indent-on-scaladoc-asterisk))))


### PR DESCRIPTION
When multi-line comment asterisk-insertion is enabled, if you hit "return" when the cursor is mid-line within a multi-line comment, the asterisk is inserted at the end of the line:

```
/**
 * This is a[]comment.
 */
```

RETURN

```
/**
 * This is a
 comment.*
 */
```

This patch fixes this behavior, inserting the asterisk after line-leading whitespace instead of at line's end. It does so while maintaining the behavior of `scala-indent:add-space-for-scaladoc-asterisk`.
