### PR TITLE
Consider bash preambles a comment

### DIFF
--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -482,12 +482,12 @@ characters and one-line strings will not be fontified."
 (defun scala-syntax:propertize-shell-preamble (start end)
   "Mark a shell preamble pair (#!/!#) at the beginning of a script as a comment."
   (save-excursion
-    (goto-char 1)
-    (when (and (re-search-forward scala-syntax:preamble-start-re end t)
-	       (= (match-beginning 0) 1))
-      (scala-syntax:put-syntax-table-property 0 '(11 . nil))
-      (when (re-search-forward scala-syntax:preamble-end-re end t)
-	(scala-syntax:put-syntax-table-property 1 '(12 . nil))))))
+    (goto-char start)
+    (when (and (= start 1)
+	       (looking-at scala-syntax:preamble-start-re))
+      (scala-syntax:put-syntax-table-property 0 '(11 . nil)))
+    (when (re-search-forward scala-syntax:preamble-end-re end t)
+      (scala-syntax:put-syntax-table-property 1 '(12 . nil)))))
 
 (defun scala-syntax:propertize-underscore-and-idrest (start end)
   "Mark all underscores (_) as symbol constituents (syntax 3) or


### PR DESCRIPTION
Heikki, I discovered that scala-mode2 doesn't handle bash preambles on scala scripts very gracefully.   To use the example from [scala-lang.org](http://www.scala-lang.org/node/166):

``` scala
  #!/bin/sh
  exec scala "$0" "$@"
  !#
  object HelloWorld {
    def main(args: Array[String]) {
      println("Hello, world! " + args.toList)
    }
  }
  HelloWorld.main(args)
```

Arbitrary bash code goes between the #! and !# marks.  This allows scala scripts to be run directly on the command line with environment variables set correctly.

It was a two line change to the syntax table to make scala-mode2 consider bash blocks to be a comment.    I am not much of an elisp guy, so I hope the syntax table was the right way to do this.
