### PR TITLE
Don't explicitly turn on font-lock

### DIFF
--- a/scala-mode2.el
+++ b/scala-mode2.el
@@ -95,7 +95,6 @@ When started, runs `scala-mode-hook'.
         indent-tabs-mode                nil
         )
   (use-local-map scala-mode-map)
-  (turn-on-font-lock)
   ;; add indent functionality to some characters
   (scala-mode-map:add-remove-indent-hook)
   (scala-mode-map:add-self-insert-hooks)


### PR DESCRIPTION
Turning on font lock directly like this was doing means you can't turn on font locking automatically if you have global font lock mode enabled.

Deleting this means that with global font lock mode enabled everything is font locked automatically as expected.
