### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ to the load-path and then to require it. For more information regarding
         to activate the mode:
 
         ```
-        (add-to-list 'auto-mode-alist '("\\.scala" . scala-mode2))
+        (add-to-list 'auto-mode-alist
+             '("\\.scala" . scala-mode2)
+             '("\\.sbt\\'" . scala-mode2)
+             )
         ```
 
     2. Manual:


### PR DESCRIPTION
If a user installs scala-mode2 via elpa we don't want to encourage them to 'require scala-mode2' as most users will stick this in their .emacs which won't work since elpa packages are loaded _after_ the emacs init file.
