### PR TITLE
scala-syntax:forward-modifiers: Unmatched [ or [^ error

### DIFF
--- a/scala-mode2-syntax.el
+++ b/scala-mode2-syntax.el
@@ -722,7 +722,7 @@ one."
   (save-match-data
     (while (scala-syntax:looking-at scala-syntax:modifiers-re)
       (scala-syntax:forward-sexp)
-      (when (scala-syntax:looking-at "[")
+      (when (scala-syntax:looking-at "[[]")
         (forward-list)))))
 
 (defun scala-syntax:looking-back-else-if-p ()


### PR DESCRIPTION
Hi. I was trying to user `scala-outline:forward-modifiers` function and found out it was failing to forward `private[this]` because of `Unmatched [ or [^ error` in `scala-syntax:looking-at` call.
Should be ok now.
