### PR TITLE
Fix exponential backoff in multiline string regexp

### DIFF
--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -99,7 +99,7 @@
 (defconst scala-syntax:multiLineStringLiteral-end-re
   "\"\"+\\(\"\\)")
 (defconst scala-syntax:multiLineStringLiteral-re
-  (concat scala-syntax:multiLineStringLiteral-start-re
+  (concat "\\(\"\\)\"\"\\(.\\)*?"
           scala-syntax:multiLineStringLiteral-end-re))
 (defconst scala-syntax:stringLiteral-re
   (concat "\\(" scala-syntax:multiLineStringLiteral-re


### PR DESCRIPTION
Hello there!

We've found an issue where emacs would freeze when using scala-mode scrolling to line https://github.com/lampepfl/dotty/blob/master/compiler/src/dotty/tools/dotc/typer/Namer.scala#L1199. If you put the point at the beginning of the trailing """ and call scala-syntax:looking-at-simplePattern-beginning, Emacs will freeze. I've traced this down to the `scala-syntax:multiLineStringLiteral-re` regexp.

Since the middle of the replaced regexp was a greedy match, it required exponential time to match (or fail to match) a very long literal.

After making `*` lazy, things no longer freeze.

I tried to make the change as unintrusive as possible. `scala-syntax:multiLineStringLiteral-start-re` could probably be changed as well. Let me know if I should continue to dig into this, I'd be willing to do it if I had some help.