### PR TITLE
Recognize worksheets as scala files

### DIFF
--- a/scala-mode.el
+++ b/scala-mode.el
@@ -175,8 +175,8 @@ When started, runs `scala-mode-hook'.
 ;;;###autoload
 (progn
   (add-to-list 'auto-mode-alist
-               '("\\.\\(scala\\|sbt\\)\\'" . scala-mode))
-  (modify-coding-system-alist 'file "\\.\\(scala\\|sbt\\)\\'" 'utf-8))
+               '("\\.\\(scala\\|sbt\\|worksheet\\.sc\\)\\'" . scala-mode))
+  (modify-coding-system-alist 'file "\\.\\(scala\\|sbt\\|worksheet\\.sc\\)\\'" 'utf-8))
 
 (provide 'scala-mode)
 ;;; scala-mode.el ends here


### PR DESCRIPTION
Worksheets format is "*.worksheet.sc". They are kind of live file evaluation tools:
![2020-05-24-125807_539x232_scrot](https://user-images.githubusercontent.com/10478402/82752428-3e223e00-9dbe-11ea-8667-64426eb547b3.png)

It would be good to have them by default associated, it will automatically highlight code and enable scala-lsp which will evaluate worksheet.