### PR TITLE
feat: add Scala 3 keywords

### DIFF
--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -283,11 +283,12 @@
   (concat "\\(^\\|[^`'_]\\)\\(" scala-syntax:value-keywords-unsafe-re "\\)"))
 
 (defconst scala-syntax:other-keywords-unsafe-re
-  (regexp-opt '("abstract" "case" "catch" "class" "def" "do" "else" "extends"
-                "final" "finally" "for" "forSome" "if" "implicit" "import"
-                "lazy" "match" "new" "object" "override" "package" "private"
-                "protected" "return" "sealed" "throw" "trait" "try" "type"
-                "val" "var" "while" "with" "yield" "inline") 'words))
+  (regexp-opt '("abstract" "case" "catch" "class" "def" "do" "else" "enum"
+                "export" "extends" "final" "finally" "for" "given" "forSome"
+                "if" "implicit" "import" "lazy" "match" "new" "object"
+                "override" "package" "private" "protected" "return" "sealed"
+                "then" "throw" "trait" "try" "type" "val" "var" "while"
+                "with" "yield" "inline") 'words))
 
 (defconst scala-syntax:other-keywords-re
   (concat "\\(^\\|[^`'_]\\)\\(" scala-syntax:other-keywords-unsafe-re "\\)"))

--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -288,7 +288,13 @@
                 "if" "implicit" "import" "lazy" "match" "new" "object"
                 "override" "package" "private" "protected" "return" "sealed"
                 "then" "throw" "trait" "try" "type" "val" "var" "while"
-                "with" "yield" "inline") 'words))
+                "with" "yield"
+                ;; "Soft" keywords https://dotty.epfl.ch/docs/internals/syntax.html#soft-keywords
+                ;; Presumably this means they do not apply in all contexts. Do
+                ;; not know of a way to support this in Emacs, so preferring
+                ;; supporting them everywhere, as regular keywords.
+                "as" "derives" "end" "extension" "inline" "opaque" "open"
+                "transparent" "using") 'words))
 
 (defconst scala-syntax:other-keywords-re
   (concat "\\(^\\|[^`'_]\\)\\(" scala-syntax:other-keywords-unsafe-re "\\)"))

--- a/scala-mode.el
+++ b/scala-mode.el
@@ -30,7 +30,7 @@
            emacs-major-version  emacs-minor-version)))
 
 (defgroup scala nil
-  "A programming mode for the Scala language 2.9"
+  "A programming mode for the Scala language 2/3"
   :group 'languages)
 
 (defmacro scala-mode:make-local-variables (&rest quoted-names)

--- a/scala-mode.el
+++ b/scala-mode.el
@@ -30,7 +30,7 @@
            emacs-major-version  emacs-minor-version)))
 
 (defgroup scala nil
-  "A programming mode for the Scala language 2/3"
+  "A programming mode for the Scala language 2 and 3"
   :group 'languages)
 
 (defmacro scala-mode:make-local-variables (&rest quoted-names)


### PR DESCRIPTION
Based on [the docs](https://dotty.epfl.ch/docs/internals/syntax.html).

1. Scala 3 is not perfectly backwards compatible, but is significantly backwards
   compatible, with Scala 2. Therefore, it seems reasonable at a syntax level to
   begin with the assumption that they are sufficiently compatible that we can
   just start migrating towards the grammar of Scala 3.
2. Scala 3 has reserved more keywords. Arguably it's a benefit, even if you are
   writing Scala 2 code, to be made aware of the Scala 3 keywords by way of
   syntax highlighting. That way you have an opportunity to rename your
   variables before ever upgrading to 3.
3. The lack of highlighting new keywords is probably the most obvious lack of
   highlighting w.r.t. to the new syntax; i.e., this is a "do 20%, get 80%"
   scenario.

Overall this seems to me like a fairly simple and safe step toward adopting
Scala 3 syntax.