### PR TITLE
feat: support trailing commas (>= Scala 2.12.2)

### DIFF
--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -479,7 +479,7 @@ special word found. Special words include 'yield', 'else',
 
 (defun scala-indent:goto-list-anchor (&optional point)
   "Moves back to the point whose column will be used to indent
-list rows at current point (or point 'point'). Returns the new
+list rows at current point (or point `point'). Returns the new
 point or nil if the point is not in a list element > 1."
   (let ((list-beg (scala-syntax:list-p point)))
     (when list-beg

--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -943,7 +943,7 @@ not. A list must be either enclosed in parentheses or start with
     ;; first check that the previous line ended with ','
     (when point (goto-char point))
     (scala-syntax:beginning-of-code-line)
-    (when (scala-syntax:looking-back-token "," 1)
+    (when (and (scala-syntax:looking-back-token "," 1) (not (looking-at-p ")")))
       (goto-char (match-beginning 0))
       (let ((parenpoint (nth 1 (syntax-ppss))))
         (if (and parenpoint (or (= (char-after parenpoint) ?\()


### PR DESCRIPTION
Trailing commas were added in Scala
[2.12.2](https://github.com/scala/scala/releases/tag/v2.12.2).

Thought that before I jumped all the way in on the Scala 3 upgrade I would try
patching something that has been bugging me w.r.t. the Scala 2 implementation.

Not 100% sure this is the most surgical fix. Will be testing locally and would
love feedback.