### PR TITLE
fix: `//`-comments filled incorrectly (`//` not acting as prefix)

### DIFF
--- a/scala-mode.el
+++ b/scala-mode.el
@@ -115,6 +115,7 @@ When started, runs `scala-mode-hook'.
    'parse-sexp-lookup-properties
    'fill-paragraph-function
    'adaptive-fill-function
+   'adaptive-fill-regexp
    'adaptive-fill-first-line-regexp
    'comment-start
    'comment-end
@@ -150,6 +151,7 @@ When started, runs `scala-mode-hook'.
         paragraph-separate              scala-paragraph:paragraph-separate-re
         fill-paragraph-function         'scala-paragraph:fill-paragraph
         adaptive-fill-function          'scala-paragraph:fill-function
+        adaptive-fill-regexp            "[ \t]*\\(//+[ \t]*\\)*"
         adaptive-fill-first-line-regexp scala-paragraph:fill-first-line-re
         comment-start                   "// "
         comment-end                     ""


### PR DESCRIPTION
This is the same problem for Scala as described [here](https://github.com/syl20bnr/spacemacs/issues/11326) for F#.

I've been using this for weeks and it has been working well. Let me know if there are specific tests you think should be run.