### PR TITLE
Don't make post-self-insert-hook local variable.

### DIFF
--- a/scala-mode-map.el
+++ b/scala-mode-map.el
@@ -13,13 +13,13 @@
 
 (defun scala-mode-map:add-self-insert-hooks ()
   (add-hook 'post-self-insert-hook
-            'scala-indent:indent-on-parentheses)
+            'scala-indent:indent-on-parentheses nil t)
   (add-hook 'post-self-insert-hook
-            'scala-indent:indent-on-special-words)
+            'scala-indent:indent-on-special-words nil t)
   (add-hook 'post-self-insert-hook
-            'scala-indent:indent-on-scaladoc-asterisk)
+            'scala-indent:indent-on-scaladoc-asterisk nil t)
   (add-hook 'post-self-insert-hook
-            'scala-indent:fix-scaladoc-close))
+            'scala-indent:fix-scaladoc-close nil t))
 
 (defun scala-mode-map:add-remove-indent-hook ()
   (add-hook 'post-command-hook

--- a/scala-mode.el
+++ b/scala-mode.el
@@ -106,7 +106,6 @@ When started, runs `scala-mode-hook'.
 ;  :abbrev
 
   (scala-mode:make-local-variables
-   'post-self-insert-hook
    'syntax-propertize-function
    'font-lock-syntactic-face-function
    'font-lock-defaults


### PR DESCRIPTION
Instead use additional argument to add-hook to add local hooks. This
fixes a case when smartparens is loaded after scala-mode and adds its
hook to post-self-insert-hook which intended to be global.