### PR TITLE
Fix Fontification of Interpolation Strings in some Circumstances

### DIFF
--- a/scala-mode-fontlock.el
+++ b/scala-mode-fontlock.el
@@ -487,7 +487,7 @@ Does not continue past limit.
     (scala-font-lock:mark-floatingPointLiteral . font-lock-constant-face)
     (scala-font-lock:mark-integerLiteral . font-lock-constant-face)
 
-    (scala-syntax:interpolation-matcher 0 font-lock-variable-name-face t)
+    (scala-syntax:interpolation-matcher 1 font-lock-variable-name-face t)
 
     ))
 

--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -156,7 +156,9 @@
           "\\|" "null" "\\)"))
 
 (defconst scala-syntax:interpolation-re
-  (concat "\\(" "\\$"  scala-syntax:id-re "\\|" "\\${[^}\n\\\\]*}" "\\)"))
+  (concat "\\(?:\\=\\|[^\\$]\\)\\(?:\\$\\$\\)*\\(\\$"
+          (string-replace "\\$" "" scala-syntax:id-re)
+          "\\|" "\\${[^}\n\\\\]*}" "\\)"))
 
 (defun scala-syntax:interpolation-matcher (end)
   (let* ((pos nil)

--- a/test/scala-mode-test.el
+++ b/test/scala-mode-test.el
@@ -176,3 +176,15 @@ comment. A concrete example may be viewed at https://github.com/scala/scala/blob
    "/* &*/"
    "110111"
    "DDDOOO"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-24 ()
+  (smt:test
+   "val c = s\"$$sum $$$sum $$$$sum\""
+   "2220201027112220111222011112227"
+   "KKK-V-K--SSSSSSSSSVVVVSSSSSSSSS"))
+
+(ert-deftest smt:syntax-class-and-font-lock-test-25 ()
+  (smt:test
+   "val c = s\"$sum$sum $sum$$sum\""
+   "22202010271222122201222112227"
+   "KKK-V-K--SVVVVVVVVSVVVVSSSSSS"))


### PR DESCRIPTION
Hi, this PR fixes fontification of interpolation strings in circumstances where the `$` character appears more than once in sequence, for example before:
![interpolation-strings-before](https://user-images.githubusercontent.com/17688577/188456653-703a09c0-b8b4-4a6f-83ef-2a71759bd48b.png)
After:
![interpolation-strings-after](https://user-images.githubusercontent.com/17688577/188456671-e7460427-7af1-4e06-83fc-198462a7b911.png)

Essentially, `scala-syntax:interpolation-re` has been tweaked so that it only matches `$` at the start of the string, and only the last dollar sign in expressions where an odd number of dollar signs occur.  Could also fontify `$$` in interpolation strings to make it clear they're special.

lmk what you think, hopefully I've caught all the edge cases.  Thanks, Laurence