### PR TITLE
Enable lexical binding and fix more warnings uncovered as result

### DIFF
--- a/scala-mode-fontlock.el
+++ b/scala-mode-fontlock.el
@@ -1,4 +1,4 @@
-;;; scala-mode-fontlock.el - Major mode for editing scala, font-lock
+;;; scala-mode-fontlock.el - Major mode for editing scala, font-lock -*- lexical-binding: t -*-
 ;;; Copyright (c) 2012 Heikki Vesalainen
 ;;; For information on the License, see the LICENSE file
 

--- a/scala-mode-imenu.el
+++ b/scala-mode-imenu.el
@@ -1,4 +1,4 @@
-;;; scala-mode-imenu.el - Major mode for editing scala
+;;; scala-mode-imenu.el - Major mode for editing scala -*- lexical-binding: t -*-
 ;;; Copyright (c) 2014 Heikki Vesalainen
 ;;; For information on the License, see the LICENSE file
 
@@ -131,4 +131,4 @@
 
 
 (provide 'scala-mode-imenu)
-;;; scala-mode-imenu.el ends here
+;;; scala-mode-imenu.el ends here -*- lexical-binding: t -*-

--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -922,10 +922,6 @@ of a line inside a multi-line comment "
       (insert "*")
       (scala-indent:indent-on-scaladoc-asterisk))))
 
-(defun scala-mode:indent-scaladoc-asterisk (&optional insert-space-p)
-  (message "scala-mode:indent-scaladoc-asterisk has been deprecated"))
-
-
 (defun scala-indent:fixup-whitespace ()
   "scala-mode version of `fixup-whitespace'"
   (interactive "*")

--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -1,4 +1,4 @@
-;;; scala-mode.el - Major mode for editing scala, indenting
+;;; scala-mode.el - Major mode for editing scala, indenting -*- lexical-binding: t -*-
 ;;; Copyright (c) 2012 Heikki Vesalainen
 ;;; For information on the License, see the LICENSE file
 

--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -583,7 +583,7 @@ keyword, or nil if not."
 ;;; Block
 ;;;
 
-(defun scala-indent:goto-block-anchor (&optional point)
+(defun scala-indent:goto-block-anchor ()
   "Moves back to the point whose column will be used as the
 anchor for calculating block indent for current point (or point
 `point'). Returns point or (point-min) if not inside a block."
@@ -759,7 +759,7 @@ cannot be determined."
          (scala-indent:goto-list-anchor scala-indent:resolve-list-step)
          (scala-indent:goto-body-anchor scala-indent:resolve-body-step)
          (scala-indent:goto-run-on-anchor scala-indent:resolve-run-on-step)
-         (scala-indent:goto-block-anchor scala-indent:resolve-block-step)
+         (scala-indent:goto-block-anchor)
      )
        point)
       0))

--- a/scala-mode-lib.el
+++ b/scala-mode-lib.el
@@ -1,4 +1,4 @@
-;;; scala-mode-lib.el - Major mode for editing scala, common functions
+;;; scala-mode-lib.el - Major mode for editing scala, common functions -*- lexical-binding: t -*-
 ;;; Copyright (c) 2012 Heikki Vesalainen
 ;;; For information on the License, see the LICENSE file
 

--- a/scala-mode-map.el
+++ b/scala-mode-map.el
@@ -1,4 +1,4 @@
-;;; scala-mode-map.el - Major mode for editing scala, keyboard map
+;;; scala-mode-map.el - Major mode for editing scala, keyboard map -*- lexical-binding: t -*-
 ;;; Copyright (c) 2012 Heikki Vesalainen
 ;;; For information on the License, see the LICENSE file
 

--- a/scala-mode-paragraph.el
+++ b/scala-mode-paragraph.el
@@ -1,4 +1,4 @@
-;;; scala-mode-paragraph.el - Major mode for editing scala, paragraph
+;;; scala-mode-paragraph.el - Major mode for editing scala, paragraph -*- lexical-binding: t -*-
 ;;; detection and fill
 ;;; Copyright (c) 2012 Heikki Vesalainen For information on the License,
 ;;; see the LICENSE file

--- a/scala-mode-prettify-symbols.el
+++ b/scala-mode-prettify-symbols.el
@@ -1,4 +1,4 @@
-;;; scala-mode-prettify-symbols.el --- Prettifying scala symbols -*- coding: utf-8; -*-
+;;; scala-mode-prettify-symbols.el --- Prettifying scala symbols -*- coding: utf-8; lexical-binding: t -*-
 
 ;; Copyright (c) 2016 Merlin Göttlinger
 ;; License: http://www.gnu.org/licenses/gpl.html
@@ -92,4 +92,4 @@ cats/scalaz/...).")
   :group 'scala)
 
 (provide 'scala-mode-prettify-symbols)
-;;; scala-mode-prettify-symbols.el ends here
+;;; scala-mode-prettify-symbols.el ends here -*- lexical-binding: t -*-

--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -1,4 +1,4 @@
-;;;; scala-mode-syntax.el - Major mode for editing scala, syntax
+;;;; scala-mode-syntax.el - Major mode for editing scala, syntax -*- lexical-binding: t -*-
 ;;; Copyright (c) 2012 Heikki Vesalainen
 ;;; For information on the License, see the LICENSE file
 

--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -751,8 +751,7 @@ further than max-chars starting after skipping any ignorable."
   (save-excursion
     ;; skip back all comments
     (scala-syntax:skip-backward-ignorable)
-    (let ((end (point))
-          (limit (when max-chars (- (point) max-chars))))
+    (let ((limit (when max-chars (- (point) max-chars))))
       ;; skip back punctuation or ids (words and related symbols and delimiters)
       (if (or (/= 0 (skip-chars-backward scala-syntax:delimiter-group limit))
               (/= 0 (skip-syntax-backward "." limit))

--- a/scala-mode-syntax.el
+++ b/scala-mode-syntax.el
@@ -500,7 +500,7 @@
 
     (setq scala-syntax:syntax-table syntab)))
 
-(defun scala-syntax:propertize-extend-region (start end)
+(defun scala-syntax:propertize-extend-region (_start _end)
   "See syntax-propertize-extend-region-functions"
   ;; nothing yet
   nil)

--- a/scala-mode.el
+++ b/scala-mode.el
@@ -1,4 +1,4 @@
-;;; scala-mode.el --- Major mode for editing Scala
+;;; scala-mode.el --- Major mode for editing Scala -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2012 Heikki Vesalainen
 
@@ -182,4 +182,4 @@ When started, runs `scala-mode-hook'.
   (modify-coding-system-alist 'file "\\.\\(scala\\|sbt\\|worksheet\\.sc\\)\\'" 'utf-8))
 
 (provide 'scala-mode)
-;;; scala-mode.el ends here
+;;; scala-mode.el ends here -*- lexical-binding: t -*-

--- a/scala-mode.el
+++ b/scala-mode.el
@@ -66,9 +66,9 @@ If there is no plausible default, return nil."
 (defun scala-mode:forward-sexp-function (&optional count)
   (unless count (setq count 1))
   (if (< count 0)
-      (dotimes (n (abs count))
+      (dotimes (_ (abs count))
         (scala-syntax:backward-sexp))
-    (dotimes (n count)
+    (dotimes (_ count)
       (scala-syntax:forward-sexp))))
 
 ;;;###autoload

--- a/scala-organise.el
+++ b/scala-organise.el
@@ -1,4 +1,4 @@
-;;; scala-organise.el --- organise scala imports -*- lexical-binding: t -*-
+;;; scala-organise.el --- organise scala imports -*- lexical-binding: t -*- -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2022 Sam Halliday
 ;; License: GPL 3 or any later version
@@ -100,4 +100,4 @@ converted into a single element list before being appended."
     (cons (cons key update) alist)))
 
 (provide 'scala-organise)
-;;; scala-organise.el ends here
+;;; scala-organise.el ends here -*- lexical-binding: t -*-


### PR DESCRIPTION
This fixes warnings about missing `lexical-binding` directive and warnings about unused parameters.

This contains one arguable change: commit `Remove scala-mode:indent-scaladoc-asterisk that's deprecated since 2012` removes a no-op function that was doing nothing but printing a message about its deprecation since 2012. The function is the source for one of the warnings, and for some reason when I add underscore in front of the optional parameter to silence the "unused" warning, Emacs fails to parse. However, I am not sure it's worth bothering, because it's been almost 13 years at this point as the function was doing nothing but printing an error message. So I presume removing it shouldn't be a problem.