### PR TITLE
Fix #192, partially revert 202990db85d5da2872178ff2f1a92937153d446b

### DIFF
--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -759,7 +759,7 @@ cannot be determined."
          (scala-indent:goto-list-anchor scala-indent:resolve-list-step)
          (scala-indent:goto-body-anchor scala-indent:resolve-body-step)
          (scala-indent:goto-run-on-anchor scala-indent:resolve-run-on-step)
-         (scala-indent:goto-block-anchor)
+         (scala-indent:goto-block-anchor scala-indent:resolve-block-step)
      )
        point)
       0))


### PR DESCRIPTION
The line `(scala-indent:goto-block-anchor scala-indent:resolve-block-step)` is not a function call although it might look like it. It is two separate items in a list of lists passed to `scala-indent:apply-indent-rules`.