### PR TITLE
Revert "scala-mode-indent.el: remove unused arg from `goto-block-anchor`"

### DIFF
--- a/scala-mode-indent.el
+++ b/scala-mode-indent.el
@@ -583,7 +583,7 @@ keyword, or nil if not."
 ;;; Block
 ;;;
 
-(defun scala-indent:goto-block-anchor ()
+(defun scala-indent:goto-block-anchor (&optional point)
   "Moves back to the point whose column will be used as the
 anchor for calculating block indent for current point (or point
 `point'). Returns point or (point-min) if not inside a block."


### PR DESCRIPTION

This reverts commit 202990db85d5da2872178ff2f1a92937153d446b.

The code was previously only partially reverted, because some of the changes were done under assumption that it was a call of `scala-indent:goto-block-anchor` with an additional parameter, whereas the parameter is unused inside the function.

That however turned out to be a list of functions, and all of them including `scala-indent:goto-block-anchor` are called with the same parameter. So we can't remove the unused argument here, otherwise that breaks indentation.

Fixes: https://github.com/hvesalai/emacs-scala-mode/issues/192