### PR TITLE
do not convert lexical-binding to local variable

### DIFF
--- a/scala-mode-imenu.el
+++ b/scala-mode-imenu.el
@@ -6,10 +6,6 @@
 
 (require 'scala-mode-syntax)
 
-;; Make lambdas proper clousures (only in this file)
-(make-local-variable 'lexical-binding)
-(setq lexical-binding t)
-
 (defcustom scala-imenu:should-flatten-index t
   "Controls whether or not the imenu index is flattened or hierarchical."
   :type 'boolean


### PR DESCRIPTION
This fixes the warning "Making lexical-binding buffer-local while locally let-bound!" (seen if using current Emacs dev branch).

lexical-binding is already enabled in the file via comment on the first line, so we can just remove this snippet.